### PR TITLE
[WIP] Python 3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ New option `-l`. You can use list of ip addresses for getting configuration file
 
 Fix bug with incorrect test of device.
 
+Added support for Python 3
+
 If you are thinking about what to do with the copied configuration files, you can try our new tool: [Cisco Config Analysis Tool](https://github.com/cisco-config-analysis-tool/ccat)
 
 If you have any questions, please write me at telegram: @sab0tag3d

--- a/sTFTP.py
+++ b/sTFTP.py
@@ -117,7 +117,7 @@ def TftpServer(sBindIp, SocketTimeout):
                 f.close()
                 ConnDATA.close()
                 print("[INFO]:[{}]:[{}] File {}/{} finished downloading, size: {}".format(
-                    raddress, sReq, TFTP_FILES_PATH, nFile, fSize)
+                    raddress, sReq, TFTP_FILES_PATH, nFile, fSize))
                 sys.exit(0)
             if sReq == 'get':
                 data = f.read(DEF_BLKSIZE)

--- a/sTFTP.py
+++ b/sTFTP.py
@@ -14,23 +14,25 @@ MAX_BLKCOUNT = 0xffff
 
 
 def TftpServer(sBindIp, SocketTimeout):
-    print '-= DvK =- TFTP server 2017(p)'
+    print("-= DvK =- TFTP server 2017(p)")
 
+    print("[INFO]: Creating directory.")
     try:
         os.mkdir('tftp')
+        print("OK.")
     except OSError:
-        print('[INFO]: Directory already exists. OK.')
+        print("[INFO]: Directory already exists.")
 
-    print '[INFO]: binding socket ..',
+    print("[INFO]: Binding socket .. ")
     try:
         ConnUDP = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         ConnUDP.settimeout(SocketTimeout)
         ConnUDP.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         ConnUDP.bind((sBindIp, TFTP_SERVER_PORT))
     except socket.error as msg:
-        print 'error: %s' % msg
+        print("Error: {}".format(msg))
         return
-    print 'ok'
+    print("OK.")
 
     dPort = TFTP_MIN_DATA_PORT
     while True:
@@ -40,7 +42,7 @@ def TftpServer(sBindIp, SocketTimeout):
             pass
         except socket.error:
             return
-        print '[INFO]: connect from ', raddress, rport
+        print("[INFO]: Connect from {}:{}".format(raddress, rport))
         sReq = ''
         tReq = ord(buff[1])
         if tReq == TFTP_GET_BYTE:
@@ -50,41 +52,46 @@ def TftpServer(sBindIp, SocketTimeout):
             sReq = 'put'
             fMode = 'w'
         if len(sReq) == 0:
-            print '[ERR]: illegal TFTP request', tReq
+            print("[ERR]: Illegal TFTP request".format(tReq))
             sUdp = '\x00\x05\x00\x01Illegal TFTP request\x00'
             ConnUDP.sendto(sUdp, (raddress, rport))
             continue
         ss = buff[2:].split('\0')
         nFile = ss[0]
         sType = ss[1]
-        print '[INFO]:[' + raddress + '] ' + sReq + 'ing file', nFile, sType
+        print("[INFO]:[{}] {}ting file {} {}".format(raddress, sReq, nFile, sType))
+
         if (sType == 'octet'):
             fMode += 'b'
+
         try:
             f = open(TFTP_FILES_PATH + '/' + nFile, fMode)
         except IOError:
-            print '[INFO]:[' + raddress + ']:[' + sReq + '] error open file: ' + TFTP_FILES_PATH + '/' + nFile
+            print("[INFO]:[{}]:[{}] Error opening file: {}/{}".format(raddress, sReq, TFTP_FILES_PATH, nFile))
             sUdp = '\x00\x05\x00\x01Error open file\x00'
             ConnUDP.sendto(sUdp, (raddress, rport))
             continue
+
         try:
             ConnDATA = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             ConnDATA.settimeout(SocketTimeout)
             ConnDATA.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             ConnDATA.bind(('', dPort))
         except socket.error:
-            print '[ERR]:[' + raddress + ']:[' + sReq + '] error binding dataport', dPort
+            print("[ERR]:[{}]:[{}] Error binding data port {}".format(raddress, sReq, dPort))
             sUdp = '\x00\x05\x00\x01Internal error\x00'
             ConnUDP.sendto(sUdp, (raddress, rport))
             f.close()
             continue
-        print '[INFO]:[' + raddress + ']:[' + sReq + '] success binding data port', dPort
+
+        print("[INFO]:[{}]:[{}] Success binding data port {}".format(raddress, sReq, dPort))
+
         dPort += 1
         if dPort == TFTP_MAX_DATA_PORT:
             dPort = TFTP_MIN_DATA_PORT
         child_pid = os.fork()
         if child_pid < 0:
-            print '[ERR]:[' + raddress + ']:[' + sReq + '] error forking new process'
+            print("[ERR]:[{}]:[{}] Error forking new process".format(raddress, sReq))
             sUdp = '\x00\x05\x00\x01Internal error\x00'
             ConnUDP.sendto(sUdp, (raddress, rport))
             f.close()
@@ -95,20 +102,22 @@ def TftpServer(sBindIp, SocketTimeout):
                 sUdp = '0004' + ('%04x' % 0)
                 ConnDATA.sendto(sUdp.decode('hex'), (raddress, rport))
                 fSize = 0
-                buffer, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
-                while buffer:
-                    fSize += len(buffer[4:])
-                    f.write(buffer[4:])
-                    sUdp = '\x00\x04' + buffer[2:4]
+                buff, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
+                while buff:
+                    fSize += len(buff[4:])
+                    f.write(buff[4:])
+                    sUdp = '\x00\x04' + buff[2:4]
                     ConnDATA.sendto(sUdp, (raddress, rport))
-                    if len(buffer[4:]) < DEF_BLKSIZE:
+                    if len(buff[4:]) < DEF_BLKSIZE:
                         break
-                    buffer, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
+                    buff, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
                     if int(fSize / ECHO_FILE_SIZE) * ECHO_FILE_SIZE == fSize:
-                        print '[INFO]:[' + raddress + ']:[' + sReq + '] file ' + TFTP_FILES_PATH + '/' + nFile + ' downloading, size:', fSize
+                        print("[INFO]:[{}]:[{}] File {}/{} downloading, size: {}".format(
+                            raddress, sReq, TFTP_FILES_PATH, nFile, fSize))
                 f.close()
                 ConnDATA.close()
-                print '[INFO]:[' + raddress + ']:[' + sReq + '] file ' + TFTP_FILES_PATH + '/' + nFile + ' finish download, size:', fSize
+                print("[INFO]:[{}]:[{}] File {}/{} finished downloading, size: {}".format(
+                    raddress, sReq, TFTP_FILES_PATH, nFile, fSize)
                 sys.exit(0)
             if sReq == 'get':
                 data = f.read(DEF_BLKSIZE)
@@ -118,28 +127,29 @@ def TftpServer(sBindIp, SocketTimeout):
                     sUdp = ('0003' + ('%04x' % j)).decode('hex') + data
                     ConnDATA.sendto(sUdp, (raddress, rport))
                     try:
-                        buffer, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
+                        buff, (raddress, rport) = ConnDATA.recvfrom(MAX_BLKSIZE)
                     except socket.error:
-                        print '[ERR]:[' + raddress + ']:[' + sReq + '] error upload file ' + TFTP_FILES_PATH + '/' + nFile
+                        print("[ERR]:[{}]:[{}] Error uploading file {}/{}".format(raddress, sReq, TFTP_FILES_PATH, nFile))
                         break
-                    nBlock = int(buffer[2:4].encode('hex'), 16)
-                    if ord(buffer[1]) != 4 or nBlock != j:
-                        print '[ERR]:[' + raddress + ']:[' + sReq + '] answer packet not valid:', ord(
-                            buffer[1]), nBlock, j
+                    nBlock = int(buff[2:4].encode('hex'), 16)
+                    if ord(buff[1]) != 4 or nBlock != j:
+                        print("[ERR]:[{}]:[{}] Answer packet not valid: {}".format(raddress, sReq, ord(buff[1]), nBlock, j))
                         break
                     if len(data) < DEF_BLKSIZE:
                         break
                     data = f.read(DEF_BLKSIZE)
                     fSize += len(data)
                     if int(fSize / ECHO_FILE_SIZE) * ECHO_FILE_SIZE == fSize:
-                        print '[INFO]:[' + raddress + ']:[' + sReq + '] file ' + TFTP_FILES_PATH + '/' + nFile + ' uploading success, size:', fSize
+                        print("[INFO]:[{}]:[{}] File {}/{} uploading success, size: {}".format(
+                            raddress, sReq, TFTP_FILES_PATH, nFile, fSize))
                     if j == MAX_BLKCOUNT:
                         j = 0
                     else:
                         j += 1
                 f.close()
                 ConnDATA.close()
-                print '[INFO]:[' + raddress + ']:[' + sReq + '] file ' + TFTP_FILES_PATH + '/' + nFile + ' finish upload, size:', fSize
+                print("[INFO]:[{}]:[{}] File {}/{} finished uploading, size: {}".format(
+                    raddress, sReq, TFTP_FILES_PATH, nFile, fSize))
                 sys.exit(0)
             sys.exit(0)
 


### PR DESCRIPTION
Hello! Here's a PR to add Python 3 support to SIET.

Marked WIP because I still want to test some of the more invasive features to make sure everything works. The TFTP server logic and all syntax has been made to support both Python 2 and 3. I think the hex encode/decode logic can be cleaned up even further because the Python 3 method is backwards compatible with Python 2.

Most of what I've been able to test so far has been config file retrieval. I have a Cisco device to experiment with but I don't think it supports SMI.

Happy to answer any questions there may be. In the future, we might want to consider dropping Python 2 support entirely but I think that's a way off yet.